### PR TITLE
refactor: update namespace and dependencies to use easy-http/contracts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^7.4|^8.0",
         "ext-json": "*",
         "symfony/http-client": "^5.1",
-        "easy-http/layer-contracts": "^1.0"
+        "easy-http/contracts": "^2.0"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^7.0",

--- a/src/SymfonyAdapter.php
+++ b/src/SymfonyAdapter.php
@@ -2,10 +2,10 @@
 
 namespace EasyHttp\SymfonyAdapter;
 
-use EasyHttp\LayerContracts\Contracts\HttpClientAdapter;
-use EasyHttp\LayerContracts\Contracts\HttpClientRequest;
-use EasyHttp\LayerContracts\Contracts\HttpClientResponse;
-use EasyHttp\LayerContracts\Exceptions\HttpClientException;
+use EasyHttp\Contracts\Contracts\HttpClientAdapter;
+use EasyHttp\Contracts\Contracts\HttpClientRequest;
+use EasyHttp\Contracts\Contracts\HttpClientResponse;
+use EasyHttp\Contracts\Exceptions\HttpClientException;
 use Symfony\Component\HttpClient\Exception\ClientException;
 use Symfony\Component\HttpClient\Exception\RedirectionException;
 use Symfony\Component\HttpClient\Exception\ServerException;

--- a/src/SymfonyClient.php
+++ b/src/SymfonyClient.php
@@ -2,9 +2,9 @@
 
 namespace EasyHttp\SymfonyAdapter;
 
-use EasyHttp\LayerContracts\AbstractClient;
-use EasyHttp\LayerContracts\Contracts\HttpClientAdapter;
-use EasyHttp\LayerContracts\Contracts\HttpClientRequest;
+use EasyHttp\Contracts\AbstractClient;
+use EasyHttp\Contracts\Contracts\HttpClientAdapter;
+use EasyHttp\Contracts\Contracts\HttpClientRequest;
 use EasyHttp\SymfonyAdapter\Factories\ClientFactory;
 
 class SymfonyClient extends AbstractClient

--- a/src/SymfonyRequest.php
+++ b/src/SymfonyRequest.php
@@ -2,7 +2,7 @@
 
 namespace EasyHttp\SymfonyAdapter;
 
-use EasyHttp\LayerContracts\Common\ClientRequest;
+use EasyHttp\Contracts\Common\ClientRequest;
 
 class SymfonyRequest extends ClientRequest
 {

--- a/src/SymfonyResponse.php
+++ b/src/SymfonyResponse.php
@@ -2,8 +2,8 @@
 
 namespace EasyHttp\SymfonyAdapter;
 
-use EasyHttp\LayerContracts\Contracts\HttpClientResponse;
-use EasyHttp\LayerContracts\Exceptions\ImpossibleToParseJsonException;
+use EasyHttp\Contracts\Contracts\HttpClientResponse;
+use EasyHttp\Contracts\Exceptions\ImpossibleToParseJsonException;
 use EasyHttp\SymfonyAdapter\Concerns\NeedsParseHeaders;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests;
 
-use EasyHttp\LayerContracts\Contracts\HttpClientAdapter;
-use EasyHttp\LayerContracts\Contracts\HttpClientRequest;
+use EasyHttp\Contracts\Contracts\HttpClientAdapter;
+use EasyHttp\Contracts\Contracts\HttpClientRequest;
 use PHPUnit\Framework\TestCase;
 use Tests\Concerns\HasMock;
 use Tests\Mocks\HttpInfo;

--- a/tests/SymfonyAdapterTest.php
+++ b/tests/SymfonyAdapterTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests;
 
-use EasyHttp\LayerContracts\Exceptions\HttpClientException;
+use EasyHttp\Contracts\Exceptions\HttpClientException;
 use EasyHttp\SymfonyAdapter\SymfonyAdapter;
 use EasyHttp\SymfonyAdapter\SymfonyRequest;
 use PHPUnit\Framework\TestCase;

--- a/tests/SymfonyClientTest.php
+++ b/tests/SymfonyClientTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests;
 
-use EasyHttp\LayerContracts\Exceptions\HttpClientException;
-use EasyHttp\LayerContracts\Exceptions\ImpossibleToParseJsonException;
+use EasyHttp\Contracts\Exceptions\HttpClientException;
+use EasyHttp\Contracts\Exceptions\ImpossibleToParseJsonException;
 use PHPUnit\Framework\TestCase;
 use EasyHttp\SymfonyAdapter\SymfonyClient;
 use Tests\Concerns\HasHandler;

--- a/tests/SymfonyRequestTest.php
+++ b/tests/SymfonyRequestTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests;
 
-use EasyHttp\LayerContracts\Contracts\HttpClientAdapter;
-use EasyHttp\LayerContracts\Contracts\HttpClientRequest;
+use EasyHttp\Contracts\Contracts\HttpClientAdapter;
+use EasyHttp\Contracts\Contracts\HttpClientRequest;
 use EasyHttp\SymfonyAdapter\SymfonyAdapter;
 use EasyHttp\SymfonyAdapter\SymfonyRequest;
 use Symfony\Component\HttpClient\MockHttpClient;

--- a/tests/SymfonyResponseTest.php
+++ b/tests/SymfonyResponseTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests;
 
-use EasyHttp\LayerContracts\Exceptions\ImpossibleToParseJsonException;
+use EasyHttp\Contracts\Exceptions\ImpossibleToParseJsonException;
 use EasyHttp\SymfonyAdapter\SymfonyAdapter;
 use EasyHttp\SymfonyAdapter\SymfonyClient;
 use EasyHttp\SymfonyAdapter\SymfonyRequest;


### PR DESCRIPTION
This pull request updates the project to use the `easy-http/contracts` package (version 2.0) instead of the older `easy-http/layer-contracts` package. The changes involve updating dependencies and replacing all references to the old package across the codebase and tests.